### PR TITLE
[TSK2-21] CircleButtonのonTapを非同期処理に変更

### DIFF
--- a/lib/View/Component/Parts/circle_button.dart
+++ b/lib/View/Component/Parts/circle_button.dart
@@ -21,8 +21,8 @@ class CircleButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {
-        onTap();
+      onTap: () async {
+        await onTap();
       },
       child: Container(
         decoration: BoxDecoration(


### PR DESCRIPTION
## 概要
CircleButton内のonTap処理を非同期処理にし、StatefulWidgetのビルド時にsetStateの再描画が入ってしまうエラーを解決しました。

## 確認事項
- https://www.notion.so/5eb3b2157e6c453c9556022bfe04fdda