### PR TITLE
[HOTFIX] [TSK3-62] CloudMessaging Serviceの改修とTopLoadingにおける通知購読処理の改善

### DIFF
--- a/lib/Constants/Enum/shared_preferences_keys_enum.dart
+++ b/lib/Constants/Enum/shared_preferences_keys_enum.dart
@@ -1,5 +1,5 @@
 /// SharedPreferencesで保存するキーのEnum
 /// 不変のキーのみを定義する
 enum SharedPreferencesKeysEnum {
-  appInitailized, // アプリ初期化フラグ
+  appInitialized, // アプリ初期化フラグ
 }

--- a/lib/Controller/top_loading_controller.dart
+++ b/lib/Controller/top_loading_controller.dart
@@ -57,7 +57,7 @@ class TopLoadingController extends ControllerCore {
 
     /// SharedPreferences: 起動フラグを確認
     bool? appInitailized = await _sharedPreferencesService
-        .getBool(SharedPreferencesKeysEnum.appInitailized.name);
+        .getBool(SharedPreferencesKeysEnum.appInitialized.name);
 
     /// ユーザー情報を取得
     firebase_auth.User? authUser = _authService.getUser();
@@ -187,7 +187,7 @@ class TopLoadingController extends ControllerCore {
 
     /// SharedPreferences: 起動フラグ
     _sharedPreferencesService.setBool(
-        SharedPreferencesKeysEnum.appInitailized.name, true);
+        SharedPreferencesKeysEnum.appInitialized.name, true);
 
     const HomeRoute().go(context);
   }

--- a/lib/Controller/top_loading_controller.dart
+++ b/lib/Controller/top_loading_controller.dart
@@ -56,7 +56,7 @@ class TopLoadingController extends ControllerCore {
     /// todo: 初回起動時の処理を記述
 
     /// SharedPreferences: 起動フラグを確認
-    bool? appInitailized = await _sharedPreferencesService
+    bool? appInitialized = await _sharedPreferencesService
         .getBool(SharedPreferencesKeysEnum.appInitialized.name);
 
     /// ユーザー情報を取得
@@ -88,7 +88,7 @@ class TopLoadingController extends ControllerCore {
       uid = authUser.uid;
 
       /// 起動フラグが立っていない場合はTokenの再取得
-      if (appInitailized == false || appInitailized == null) {
+      if (appInitialized == false || appInitialized == null) {
         /// Firebase: FCMトークンを取得
         await _cloudMessagingInitialize();
 
@@ -137,7 +137,7 @@ class TopLoadingController extends ControllerCore {
     /// 画面遷移
     // if (user == null) {
     //   _sharedPreferencesService.setBool(
-    //       SharedPreferencesKeysEnum.appInitailized.name, true);
+    //       SharedPreferencesKeysEnum.appInitialized.name, true);
     //   const RegisterPhysicalInfoRoute(from: Routes.root).go(context);
     // } else {
     /// シングルトンにユーザー情報を保存

--- a/lib/Service/Api/Account/account_api.dart
+++ b/lib/Service/Api/Account/account_api.dart
@@ -32,7 +32,7 @@ class AccountApi extends ApiCore with Endpoint {
   /// [fcmTokenId] FCMトークンID
   Future<int> putAccount({required String fcmTokenId}) async {
     try {
-      final ApiResponse response = await put({'fcm_token_id': fcmTokenId});
+      final ApiResponse response = await put({'fcmTokenId': fcmTokenId});
       return response.statusCode;
     } catch (e) {
       return 500;

--- a/lib/Service/Firebase/CloudMessaging/cloud_messaging_service.dart
+++ b/lib/Service/Firebase/CloudMessaging/cloud_messaging_service.dart
@@ -2,12 +2,16 @@ import 'dart:convert';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:unicorn_flutter/Constants/Enum/fcm_topic_enum.dart';
+import 'package:unicorn_flutter/Service/Firebase/Authentication/authentication_service.dart';
 import 'package:unicorn_flutter/Service/Log/log_service.dart';
 import 'package:http/http.dart' as http;
 
 class FirebaseCloudMessagingService {
   final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
+  final FirebaseAuthenticationService _authService =
+      FirebaseAuthenticationService();
+  final String _notificationServerBaseUrl =
+      dotenv.env['NOTIFICATION_SERVER_URL'] ?? '';
 
   /// 初期化
   Future<void> initialize() async {
@@ -34,26 +38,48 @@ class FirebaseCloudMessagingService {
     return await _firebaseMessaging.getToken();
   }
 
+  /// NotificationServerアクセス用のヘッダーを作成
+  Future<Map<String, String>> _makeHeader() async {
+    return <String, String>{
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ${await _authService.getIdToken()}',
+    };
+  }
+
   /// Topicを購読
-  Future<void> subscribeToTopics(List<FCMTopicEnum> topics) async {
-    final String messagingApiBaseUrl =
-        dotenv.env['MESSAGING_API_BASEURL'] ?? '';
-    for (FCMTopicEnum topic in topics) {
-      final String topicName = FCMTopicType.toStringValue(topic);
+  Future<void> subscribeToTopics(List<String> topics) async {
+    for (String topic in topics) {
       http.Response response = await http.post(
-        Uri.parse('${messagingApiBaseUrl}subscribe'),
-        headers: <String, String>{
-          'Content-Type': 'application/json',
-        },
+        Uri.parse('${_notificationServerBaseUrl}subscribe'),
+        headers: await _makeHeader(),
         body: jsonEncode(<String, dynamic>{
-          'topic': topicName,
+          'topic': topic,
           'tokens': [await getToken()],
         }),
       );
       if (response.statusCode == 200) {
-        Log.echo('Subscribed to $topicName');
+        Log.echo('Subscribed to $topic');
       } else {
-        Log.echo('Failed to subscribe to $topicName');
+        Log.echo('Failed to subscribe to $topic');
+      }
+    }
+  }
+
+  /// Topicの購読を解除
+  Future<void> unsubscribeFromTopics(List<String> topics) async {
+    for (String topic in topics) {
+      http.Response response = await http.post(
+        Uri.parse('${_notificationServerBaseUrl}unsubscribe'),
+        headers: await _makeHeader(),
+        body: jsonEncode(<String, dynamic>{
+          'topic': topic,
+          'tokens': [await getToken()],
+        }),
+      );
+      if (response.statusCode == 200) {
+        Log.echo('Unsubscribed from $topic');
+      } else {
+        Log.echo('Failed to unsubscribe from $topic');
       }
     }
   }


### PR DESCRIPTION
## 概要
NotificationServer実装に合わせてサービスの改善
・NotificationServerへのTopic購読メソッドを本実装
・SharedPreferencesを利用した初回起動フラグ実装 -> FCMTokenの再生成によるサーバー値との不整合を防ぐ
・AccountAPI PUT処理のバグ修正 @nolisio 

## 確認事項
- https://www.notion.so/5eb3b2157e6c453c9556022bfe04fdda