### PR TITLE
[HOTFIX] 家族メールに関与するPhoneNumberをすべて除外

### DIFF
--- a/lib/Controller/Profile/FamilyEmail/family_email_sync_contact_controller.dart
+++ b/lib/Controller/Profile/FamilyEmail/family_email_sync_contact_controller.dart
@@ -51,7 +51,6 @@ class FamilyEmailSyncContactController extends ControllerCore {
   bool checkDuplicate(FamilyEmailRequest syncFamilyEmail) {
     return _familyEmailList!.any((registeredEmail) =>
         (registeredEmail.email == syncFamilyEmail.email) &&
-        (registeredEmail.phoneNumber == syncFamilyEmail.phoneNumber) &&
         (registeredEmail.firstName + registeredEmail.lastName ==
             syncFamilyEmail.firstName + syncFamilyEmail.lastName));
   }

--- a/lib/Model/Entity/FamilyEmail/family_email.dart
+++ b/lib/Model/Entity/FamilyEmail/family_email.dart
@@ -6,7 +6,6 @@ class FamilyEmail {
   final String firstName;
   final String lastName;
   final String? iconImageUrl;
-  final String phoneNumber;
 
   FamilyEmail({
     required this.familyEmailId,
@@ -14,7 +13,6 @@ class FamilyEmail {
     required this.firstName,
     required this.lastName,
     this.iconImageUrl,
-    required this.phoneNumber,
   });
 
   factory FamilyEmail.fromJson(Map<String, dynamic> json) {
@@ -24,7 +22,6 @@ class FamilyEmail {
       firstName: json['firstName'],
       lastName: json['lastName'],
       iconImageUrl: json['iconImageUrl'],
-      phoneNumber: json['phoneNumber'],
     );
   }
 
@@ -35,7 +32,6 @@ class FamilyEmail {
       'firstName': firstName,
       'lastName': lastName,
       'iconImageUrl': iconImageUrl,
-      'phoneNumber': phoneNumber,
     };
   }
 

--- a/lib/Model/Entity/FamilyEmail/family_email_request.dart
+++ b/lib/Model/Entity/FamilyEmail/family_email_request.dart
@@ -6,7 +6,6 @@ class FamilyEmailRequest {
   final String lastName;
   String? iconImageUrl;
   Uint8List? avatar;
-  final String phoneNumber;
 
   FamilyEmailRequest({
     required this.email,
@@ -14,7 +13,6 @@ class FamilyEmailRequest {
     required this.lastName,
     this.iconImageUrl,
     this.avatar,
-    required this.phoneNumber,
   });
 
   factory FamilyEmailRequest.fromJson(Map<String, dynamic> json) {
@@ -22,7 +20,6 @@ class FamilyEmailRequest {
       email: json['email'],
       firstName: json['firstName'],
       lastName: json['lastName'],
-      phoneNumber: json['phoneNumber'],
     );
     if (json['avatar'] != null) {
       request.avatar = json['avatar'];
@@ -39,7 +36,6 @@ class FamilyEmailRequest {
       'lastName': lastName,
       'iconImageUrl': iconImageUrl,
       'avatar': avatar,
-      'phoneNumber': phoneNumber,
     };
   }
 }

--- a/lib/Service/Package/NativeContacts/native_contacts_service.dart
+++ b/lib/Service/Package/NativeContacts/native_contacts_service.dart
@@ -19,14 +19,10 @@ class NativeContactsService {
       final email = nativeContact.emails!.isNotEmpty
           ? nativeContact.emails!.first.value
           : '';
-      final phoneNumber = nativeContact.phones!.isNotEmpty
-          ? nativeContact.phones!.first.value?.replaceAll(RegExp(r'[^0-9]'), '')
-          : '';
       final Map<String, dynamic> contactMap = {
         'firstName': firstName,
         'lastName': lastName,
         'email': '$email',
-        'phoneNumber': '$phoneNumber',
       };
       if (nativeContact.avatar != null) {
         contactMap['avatar'] = nativeContact.avatar;


### PR DESCRIPTION
## 概要
・FamilyEmailで利用するModelからPhoneNumberを削除
・NativeContactsServiceからPhoneNumber関係の処理を削除
本番環境で正常に取得と登録ができることを確認済みです👀

## 確認事項
- https://www.notion.so/5eb3b2157e6c453c9556022bfe04fdda